### PR TITLE
feat: sets EntityEntry.State explicity to Modified when is chaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,16 +216,21 @@ personRepository.AddAll(new List<Person> { person1, person2, person3 });
 
 ## News
 
+**v1.2.0 - 2022/06**
+
+- Change! Updated support to the `EntityFrameworkCore` latest 3rd major version
+- Change! `EntityRepository` sets `EntityEntry.State` explicity to `EntityState.Modified` when change an `Entity`
+
 **v1.1.0 - 2022/01**
 
-* New! Added support to new Repository Factory features
-* New! Added capability to invokes non-standard methods defined on client
-* Change! _TEntity_ requirements on generic interface _IEntityRepository_
-* **Break Change!** Removed _DbContext_ as argument on _EntityRepositoryFactory_ constructor
+- New! Added support to new Repository Factory features
+- New! Added capability to invokes non-standard methods defined on client
+- Change! `TEntity` requirements on generic interface `IEntityRepository`
+- **Breaking Change!** Removed `DbContext` as argument on `EntityRepositoryFactory` constructor
 
 **v1.0.0 - 2020/09**
 
-* Provided initial core base
+- Provided initial core base
 
 ## Limitations and caveats
 

--- a/src/DataQI.EntityFrameworkCore/DataQI.EntityFrameworkCore.csproj
+++ b/src/DataQI.EntityFrameworkCore/DataQI.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Henrique Gouveia</Authors>
     <Description>Data Query Interface it's EntityFrameworkCore provider that use infraestructure provided by DataQI.Commons and it turns your Data Repositories a live interface.</Description>
     <Copyright>(c) Henrique Gouveia</Copyright>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="1.1.2" />
     <PackageReference Include="DataQI.Commons" Version="1.2.0" />
   </ItemGroup>

--- a/src/DataQI.EntityFrameworkCore/Repository/Support/EntityRepository.cs
+++ b/src/DataQI.EntityFrameworkCore/Repository/Support/EntityRepository.cs
@@ -95,13 +95,21 @@ namespace DataQI.EntityFrameworkCore.Repository.Support
 
         public IEnumerable<TEntity> FindAll()
         {
-            var entities = context.Set<TEntity>().AsNoTracking().ToList();
+            var entities = context
+                .Set<TEntity>()
+                .AsNoTracking()
+                .ToList();
+
             return entities;
         }
 
         public async Task<IEnumerable<TEntity>> FindAllAsync()
         {
-            var entities = await context.Set<TEntity>().AsNoTracking().ToListAsync();
+            var entities = await context
+                .Set<TEntity>()
+                .AsNoTracking()
+                .ToListAsync();
+
             return entities;
         }
 
@@ -137,17 +145,12 @@ namespace DataQI.EntityFrameworkCore.Repository.Support
             Assert.NotNull(entity, "Entity must not be null");
 
             var entityId = context.KeyOf<TEntity, TId>(entity);
-            var entityExistent = FindOne(entityId);
-            
-            if (entityExistent == null)
-            {
+            var existingEntity = FindOne(entityId);
+
+            if (existingEntity == null)
                 Insert(entity);
-            }
             else
-            {
-                context.Entry(entityExistent).CurrentValues.SetValues(entity);
-                entity = entityExistent;
-            }
+                ChangeExistingEntityValues(existingEntity, entity);
         }
 
         public async Task SaveAsync(TEntity entity)
@@ -155,17 +158,19 @@ namespace DataQI.EntityFrameworkCore.Repository.Support
             Assert.NotNull(entity, "Entity must not be null");
 
             var entityId = context.KeyOf<TEntity, TId>(entity);
-            var entityExistent = await FindOneAsync(entityId);
+            var existingEntity = await FindOneAsync(entityId);
            
-            if (entityExistent == null)
-            {
+            if (existingEntity == null)
                 await InsertAsync(entity);
-            }
             else
-            {
-                context.Entry(entityExistent).CurrentValues.SetValues(entity);
-                entity = entityExistent;
-            }
+                ChangeExistingEntityValues(existingEntity, entity);
+        }
+
+        private void ChangeExistingEntityValues(TEntity existing, TEntity entity)
+        {
+            var entityEntry = context.Entry(existing);
+            entityEntry.CurrentValues.SetValues(entity);
+            entityEntry.State = EntityState.Modified;
         }
 
         #region IDisposable Support

--- a/test/DataQI.EntityFrameworkCore.Test/DataQI.EntityFrameworkCore.Test.csproj
+++ b/test/DataQI.EntityFrameworkCore.Test/DataQI.EntityFrameworkCore.Test.csproj
@@ -22,7 +22,7 @@
     </PackageReference>
     <PackageReference Include="ExpectedObjects" Version="2.3.4" />  
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" version="3.1.26" />
     <PackageReference Include="Moq" Version="4.14.4" />
     <PackageReference Include="Sqlite.Interop.Net46.x64" Version="1.0.109" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.109" />


### PR DESCRIPTION
`EntityRepository` sets `EntityEntry.State` explicity to `EntityState.Modified` when change an `Entity`
Updated support to the `EntityFrameworkCore` latest 3rd major version